### PR TITLE
Skip .env for now 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,36 +89,32 @@ For a complete guide please check the [Wiki](https://github.com/Fruitsbytes/php-
 composer require fruitsbytes/php-moncash
 ```
 
-### Environment variables & configuration
-You can setup a .env file in the root of your project to automatically configure the client:
+### Configuration
 
-```shell
-# .env 
-
-MONCASH_CLIENT_ID="<!your-client-id/>"
-MONCASH_CLIENT_SECRET="<!your-client-secret/>"
-MONCASH_BUSINESS_KEY="<!--------/>"
-MONCASH_MODE="sandbox"
-MONCASH_LANG="env"
-MONCASH_RSA_KEY_PATH="/secure-path-to-rsa-dir/rsa.txt"
-```
 
 ```php
 // index.php
 
 use Fruitsbytes\PHP\MonCash\API\Client;
 
-$client = new Client();
+$client = new Client(
+                        [
+                            'clientSecret'     => 'my-client-secret',
+                            'clientId'         => 'my-client-key',
+                            'businessKey'      => 'my-merchant-key',
+                        ]
+                    );
 
 ```
 
-You override the Environment variables or completely ignore them:
+You can update or set the configuration:
 
 ```php
 
 use Fruitsbytes\PHP\MonCash\Configuration\Configuration;
 
 $configuration = new Configuration(["lang"=>"ht"]);
+$client = new Client($configuration);
 
 ```
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -478,22 +478,21 @@ class Configuration extends ArrayObject implements Stringable
         array $config
     ): Configuration {
 
-        $hostConfig = self::getHostConfiguration();
+//        $hostConfig = self::getHostConfiguration();
 
-        $this->mode = $config['mode'] ?? $this->mode ?? $hostConfig['mode'] ?? 'sandbox';
+        $this->mode = $config['mode'] ?? $this->mode ?? 'sandbox';
         if (in_array($this->mode, ['production', 'live', 'sandbox']) === false) {
             throw new ConfigurationException('INVALID_MODE');
         }
         $this->mode = $this->mode === 'sandbox' ? $this->mode : 'production';
 
 
-        $this->clientId        = $config['clientId'] ?? $this->clientId ?? $hostConfig['clientId'];
-        $this->lang            = $config['lang'] ?? $this->lang ?? $hostConfig['lang'];
+        $this->clientId        = $config['clientId'] ?? $this->clientId ?? "";
+        $this->lang            = $config['lang'] ?? $this->lang ?? "";
         $this->businessKey     = $config['businessKey'] ??
-                                 $this->businessKey ??
-                                 $hostConfig['businessKey'];
+                                 $this->businessKey ?? "";
         $this->timeout         = $config['timeout'] ?? $this->timeout ?? 60;
-        $this->rsaPath         = $config['rsaPath'] ?? $this->rsaPath ?? $hostConfig['rsaPath'];
+        $this->rsaPath         = $config['rsaPath'] ?? $this->rsaPath ?? "";
         $this->gatewayBase     = self::GATEWAY_BASE[$this->mode];
         $this->gatewayMerchant = self::GATEWAY_MERCHANT[$this->mode];
         $this->restApi         = self::HOST_REST_API[$this->mode];


### PR DESCRIPTION
When using the package in various deployments the .env variable is not always at the expected place. 
For now, you will have to set the configuration



```php
// index.php

use Fruitsbytes\PHP\MonCash\API\Client;

$client = new Client(
                        [
                            'clientSecret'     => 'my-client-secret',
                            'clientId'         => 'my-client-key',
                            'businessKey'      => 'my-merchant-key',
                        ]
                    );

```

closes #12